### PR TITLE
Update to Swift 2.2

### DIFF
--- a/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 1.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 1.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@
 //: [Previous](@previous)
 
 protocol Furniture {
-    typealias M
+    associatedtype M
     func mainMaterial() -> M
     func secondaryMaterial() -> M
 }

--- a/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 2.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 2.xcplaygroundpage/Contents.swift
@@ -5,7 +5,7 @@
 
 //: `mainMaterial()` and `secondaryMaterial()` must return the same types
 protocol Furniture {
-    typealias M
+    associatedtype M
     func mainMaterial() -> M // <====
     func secondaryMaterial() -> M // <====
 }

--- a/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 3.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/inferred-typealiases 3.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ struct Cotton: Material {}
 //: `mainMaterial()` and `secondaryMaterial()` may return _different_ types now
 
 protocol Furniture {
-    typealias M: Material
-    typealias M2: Material
+    associatedtype M: Material
+    associatedtype M2: Material
     func mainMaterial() -> M // <====
     func secondaryMaterial() -> M2 // <====
 }

--- a/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 1.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 1.xcplaygroundpage/Contents.swift
@@ -11,9 +11,9 @@ struct Cotton: Material {}
 
 protocol HouseholdThing { }
 protocol Furniture: HouseholdThing {
-    typealias M: Material
-    typealias M2: Material
-    typealias T: HouseholdThing
+    associatedtype M: Material
+    associatedtype M2: Material
+    associatedtype T: HouseholdThing
     
     func mainMaterial() -> M
     func secondaryMaterial() -> M2

--- a/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 2.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 2.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ struct Cotton: Material {}
 //: Alternate method for creating a factory -- we changed `factory()` to return `Self` instead of `T`
 
 protocol Furniture {
-    typealias M: Material
-    typealias M2: Material
+    associatedtype M: Material
+    associatedtype M2: Material
     
     func mainMaterial() -> M
     func secondaryMaterial() -> M2

--- a/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 3.xcplaygroundpage/Contents.swift
+++ b/swift-using-typealiases-as-generics-i.playground/Pages/typealias-for-self 3.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ struct Cotton: Material {}
 //: We changed `factory()` to return `Self` instead of `T`
 
 protocol Furniture {
-    typealias M: Material
-    typealias M2: Material
+    associatedtype M: Material
+    associatedtype M2: Material
     
     func mainMaterial() -> M
     func secondaryMaterial() -> M2


### PR DESCRIPTION
This commit
- fixes the warning: `Use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead`
